### PR TITLE
Updating scope to relaunch competition

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,18 @@ Last year, the Cosmos Network hosted the first-ever adversarial testnet to prepa
 
 Registration is closed.
 
-## Game of Zones Phase 2
+## Competition Details
 
-The Game of Zones Hub for Phase 2 is launching on May 10th. The
+The Game of Zones Hub for Phase 1b is launching on May 15th at 1:00am UTC!
 
-See Scoring guidlines [below](#phase-2-liveness).
+* The Genesis will be available soon. 
+* The ID for the hub will be `gameofzoneshub-1b`
+* Connections are rate limited, so we recommend that all teams run a full node for the competition. 
+* There is a node with open RPC on port 80 at http://35.190.35.11/
+* The hub will be centralized during the combination. The staking tokens are all controlled by iqlusion and `doubloons` will be issued to all players.
+ * Each team will receive an allocation of `doubloons` for the competition, and gas prices are set at `0.025doubloons`.
 
-The Genesis [file](goz-genesis.json) is this repo. `chain-id`= `gameofzoneshub-2`
-
-There is a node with open RPC on port 80 at http://35.190.35.11/
-
-We are rate limiting connections so we reccommend running your own full node.
-
-Public available sentry nodes are available at
+Publicly available sentry nodes are available at:
 
 ``` txt
 6ed008bf3a2ad341d84391bf47ea46e75a87e35e@35.233.155.199:26656
@@ -29,40 +28,37 @@ Seed Node
 d95a9f97e31f36d0a467e6855c71f5e5b8eccf65@34.83.90.172:26656
 ```
 
-This hub will be centralized during the combination. The staking tokens are all controlled by iqlusion and `doubloons` will be issued to all players.
+## Game of Zones Phase 1b
 
-You should have recieved `1 billion` doubloons to your account.
+Phase 1b will begin Monday, May 18th at 7:00am UTC, and will end on Thursday, May 21st at 6:59am UTC.
 
-Gas prices are set at `0.025doubloons`.
+To recapture the original spirit of Phase 1a, the objectives for Phase 1b will be different than the initial challenge.  During Phase 1b, we will be limiting the number of tokens given to each team to improve the stability of the hub, removing restrictions on trust periods in the software, and disqualifying any team that pools their genesis allocated doubloons for additional gas.
 
-Scoring will begin at **Phase 2 launches at 12:00am PST on 5/11**
+* Every team should append -1b to their chain ID. An official Team Roster that maps chain IDs and Relayer addresses to team names will be published on the GoZ Github repository on May 14th at 7pm UTC. 
+* Trust periods will be unrestricted on the software. 
+* Players will be restricted to `1.25 million doubloons` in the addresses.  
+* This amount should provide enough tokens for a minimum trust period of 10 minutes.  
+* Gas prices will be fixed at `0.0025doubloons/gas`, and a client update should cost approximately `2500 doubloons`.
 
+Before the phase begins, the GoZ Team will provide detailed documentation that shows participants how to adjust the trust period in the Relayer, how to optimize gas, how to deal with errors and recovery, and how to ensure that a client is kept alive. 
 
-### Phase 2 Versions
+The winning team for Phase 1b will have the smallest trust period on their client while maintaining the longest period of liveness. If Team A were to achieve a client trust period of 11 minutes, and Team B were to achieve a trust period of 15 minutes and both teams keep their clients alive for 72 hours, Team A would score higher. If no team is able to maintain a connection for the full 4320 minutes of Phase 1b, the winner will be decided by scoring the length of the longest lived connection over the trust period. 
 
-Players should use the following versions of `relayer`, `gaia` and/or `cosmos-sdk` respectively to participate in Phase 1:
+In terms of judging, we will combine the data from Phase 1a and Phase 1b to declare a challenge winner. During this phase of the competition, we expect to provide an overview of the active clients published to the Game of Zones GitHub repo multiple times a day.
 
+## Launching Phase 1b
 
-``` bash
-❯ gaiad version --long
-name: gaia
-server_name: gaiad
-client_name: gaiacli
-version: 0.0.0-196-gbde5e9c
-commit: bde5e9c003256cfb6417d3441889bafd14089e0b
-build_tags: netgo,ledger
-go: go version go1.14.2 darwin/amd64
+The Game of Zones Team will begin the launch process for the hub on Friday, May 15th around 1:00am UTC. In order to connect to the hub, you will need to be using the following versions of software: 
 
-❯ rly version
-version: 0.5.0
-commit: 427afec4ed60170d6dcfe0a1c3b25d86ca8433be
-cosmos-sdk: v0.34.4-0.20200507135526-b3cada10017d
-gaia: v0.0.1-0.20200507172327-bde5e9c00325
-go: go1.14.2 darwin/amd64
+Gaia (cbc3321): https://github.com/cosmos/gaia/releases/tag/goz-phase-1
+Relayer (34f0fdf): https://github.com/iqlusioninc/relayer/releases/tag/v0.5.2
 
+And for custom zone operators, update to the following CosmosSDK version:
 
+Cosmos-SDK(80be503): https://github.com/cosmos/cosmos-sdk/releases/tag/goz-phase-1
 
-```
+The Chain ID for the hub will be `gameofzoneshub-1b`. For each phase of the competition, teams should be prepared to append the phase number to their chain ID before phase launch.
+
 
 ## Game of Zones Phase 1
 
@@ -118,21 +114,7 @@ commit: 2282f8b33c7025a5e9dc6d7eacfb8c1ad9572897
 cosmos-sdk: v0.34.4-0.20200430150743-930802e7a13c
 go: go1.14 darwin/amd64
 ```
-## Phase 2: Liveness
-
-Phase 2 of Game of Zones will begin Monday, May 11th at 12am PST // 7am UTC. 
-
-The main goal of the second phase of Game of Zones is to focus on throughput, and the winning team will be the team that relays the most packets on the GoZ Hub.  In terms of scoring, 
-
-* Packets relayed to the hub by your relayer key are the most important metric to judge winning. If we were using a point system for scoring, these packets would be worth 1 point.
-* Packets relayed from the hub are the second most important metric for the week. If we were scoring these packets using a point system, they would be worth 0.5 points. 
-* Packets relayed among other chains are less important to your team’s performance than the first two metrics mentioned above. If we were using a point system for scoring, these packets would be worth 0.1 points.
-
-Additionally, for Phase 2:
-
-* All teams should append `-2` to their chain ID for Phase 2 of the competition. 
-* Given current issues with RPC, we recommend that all teams run a full node as increasing the number of operational sentry nodes will help improve overall stability.
-* If your team is relaying packets with a different address than the one that was shared with us for registration, we will be unable to see or count your performance for the week. 
+ 
 
 ## Code of Conduct
 
@@ -167,7 +149,7 @@ In addition to the weekly challenges, there will also be a handful of opportunit
 
 The goal of running an adversarial testnet challenge is to stress test the protocol-level of the Cosmos network and the IBC module. As the community and network operators become acquainted with the IBC module and setting up zones, the code will be pushed to its limit (and perhaps beyond!), as a way to observe its performance before it is released as production-ready software.
 
-Throughout the competition, we expect to see validators running their own zones and attempting to attack other zones through spamming or exploiting configurations. We also expect to see non-traditional configurations of core protocols and software that might provide specific advantages to our network operators. Additionally, we hope to observe numerous multi-hop transactions, proposer priority attacks, double spending attacks, unnoticed equivocations, and other confusion attacks that attempt to disrupt communication and operations between zones and relayers.
+Throughout the competition, we expect to see validators running their own zones and attempting to attack other zones through spamming or exploiting configurations. We also expect to see non-traditional configurations of core protocols and software that might provide specific advantages to our network operators. Additionally, we hope to observe numerous multi-hop transactions, proposer priority attacks, double spending attacks, unnoticed equivocations, and other confusion attacks that attempt to disrupt communication and operations between zones and relayers.During Phase 1b of the challenge, any team that pools their genesis allocated doubloons for additional gas will be disqualified.
 
 During the course of the game, it is forbidden to exploit security vulnerabilities in attempt to win the challenge. Participants who exploit software vulnerabilities in the IBC module or Cosmos Network will be disqualified. Participants who use social engineering or malware to attack fellow competitors will also be disqualified from the challenge. If you find a software vulnerability during the competition, please report it to  [security@cosmosnetwork.dev](http://security@cosmosnetwork.dev/)  — once IBC is added to the bug bounty program, all security bugs reported will be eligible for a bonus reward.
 
@@ -197,16 +179,16 @@ All members of the Cosmos Community are eligible and encouraged to participate i
 
 Save these important competition dates on your calendar:
 
-* ✅-Registration for Game of Zones closes on April 25, 2020 at 11:59pm PST.-
-* Game of Zones will begin on Friday, May 1, 2020.
-* The Official GoZ Opening Ceremonies Live Stream will be held on Friday, May 1, 2020 at 9am PST on our @cosmosdevs Twitch channel.
-  * **Phase 1 launches at 12:00 am PST on 5/6** and ends at 11:59am PST on 5/10, and the P1 Live Stream will be on 5/8 at 12:00pm PST.
-    * **Phase 2 launches at 12:00am PST on 5/11** and ends at 11:59PM PST on 5/15, and the P2 Live Stream will be on 5/15 at 12:00pm PST.
-    * **Phase 3 launches at 12:00am PST on 5/18** and ends at 11:59pm PST on 5/22, and the P3 Live Stream will be on 5/22 at 12:00pm PST.
+* ✅Registration for Game of Zones closes on April 25, 2020 at 11:59pm PST.
+* ✅Game of Zones will begin on Friday, May 1, 2020.
+* The Official GoZ Opening Ceremonies Live Stream was held on Friday, May 1, 2020 at 9am PST on our @cosmosdevs Twitch channel.
+  * Phase 1b will begin Monday, May 18th at 7:00am UTC, and will end on Thursday, May 21st at 6:59am UTC.
+  * Phase 2 will begin Monday, May 25th at 7:00am UTC, and will end on Friday, May 28th at 6:59am UTC. 
+  * Phase 3 will begin on Monday, June 1st at 7:00am UTC, and will end on Friday, June 6th at 6:59am UTC. 
 
-* Game of Zones will close on Friday, May 22nd, 2020 at 11:59pm PST.
+* Game of Zones will close on Friday, May 22nd, 2020 at 6:49am UTC.
 
-* The Official GoZ Closing Ceremonies Live Stream will be held on Thursday, May 28th, 2020 at 9am PST.
+* The Official GoZ Closing Ceremonies Live Stream will be held on Wednesday, June 10th at 7:00pm UTC.
 
 Wherever possible, we will strive to find times that are convenient for participants distributed across diverse time zones.
 


### PR DESCRIPTION
* Updating important dates section and scope to reflect competition commitments on GoZ blog published 5/13.
* Updated software versions and competition details at the top of readme for participants.
* Included date for launching GoZ hub for P1b. 
* Removed out of date details for Phase 2. 

Moving forward, we will publish details for upcoming phases in reverse chronological order, and we will strive to publish times in UTC with the occasional PST conversion.